### PR TITLE
feat(build): Uses the base folder names as the name of the zip file

### DIFF
--- a/config/ZipperPlugin.js
+++ b/config/ZipperPlugin.js
@@ -1,8 +1,18 @@
 const path = require("path")
 const AdmZip = require("adm-zip")
+const sanitize = require("sanitize-filename")
 
 // get the name of the base directory
-const projectName = path.basename(path.resolve('.'))
+let projectName = path.basename(path.resolve('.'))
+
+// replace spaces with underscores
+projectName = projectName.replace(/\s/g, '-')
+
+// lowercase the name
+projectName = projectName.toLowerCase()
+
+// replace eventual unsafe and invalid characters
+projectName = sanitize(projectName)
 
 const defaultOptions = {
   outputPath: path.resolve(__dirname, `../dist-zipped/${projectName}.zip`)

--- a/config/ZipperPlugin.js
+++ b/config/ZipperPlugin.js
@@ -1,9 +1,11 @@
 const path = require("path")
 const AdmZip = require("adm-zip")
 
+// get the name of the base directory
+const projectName = path.basename(path.resolve('.'))
 
 const defaultOptions = {
-  outputPath: path.resolve(__dirname, "../dist-zipped/project.zip")
+  outputPath: path.resolve(__dirname, `../dist-zipped/${projectName}.zip`)
 }
 
 /**

--- a/config/ZipperPlugin.js
+++ b/config/ZipperPlugin.js
@@ -1,6 +1,5 @@
 const path = require("path")
 const AdmZip = require("adm-zip")
-const sanitize = require("sanitize-filename")
 
 // get the name of the base directory
 let projectName = path.basename(path.resolve('.'))
@@ -11,8 +10,8 @@ projectName = projectName.replace(/\s/g, '-')
 // lowercase the name
 projectName = projectName.toLowerCase()
 
-// replace eventual unsafe and invalid characters
-projectName = sanitize(projectName)
+// replace characters with URL compatible ones
+projectName = encodeURIComponent(projectName)
 
 const defaultOptions = {
   outputPath: path.resolve(__dirname, `../dist-zipped/${projectName}.zip`)

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "^6.4.0",
     "html-webpack-plugin": "^5.4.0",
+    "sanitize-filename": "^1.6.3",
     "style-loader": "^3.3.0",
     "webpack": "^5.59.0",
     "webpack-cli": "^4.9.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "^6.4.0",
     "html-webpack-plugin": "^5.4.0",
-    "sanitize-filename": "^1.6.3",
     "style-loader": "^3.3.0",
     "webpack": "^5.59.0",
     "webpack-cli": "^4.9.1",


### PR DESCRIPTION
Instead of calling every export project.zip, it now takes the base folder name as the name of the zip.
Avoids confusion when you have multiple projects going.