### PR TITLE
Feature: live params

### DIFF
--- a/project/public/index.html
+++ b/project/public/index.html
@@ -327,31 +327,33 @@
         },
       }
 
+      // Utility function to get parameter value, default value, or a random value
+      function getParamValue(param, def, processor) {
+        if (typeof param !== "undefined") return param
+        if (typeof def.default !== "undefined") return def.default
+        return processor.random(def)
+      }
+
       // params are injected into the piece using the binary representation of the
       // numbers, to keep precision
       function serializeParams(params, definition) {
-        // a single hex string will be used for all the params
-        let bytes = ""
-        if (!definition) return bytes
-        // loop through each parameter from the definition to find the associated
-        // parameter as set on the UI
+        // Initialization of the hex string for parameters
+        let hexString = ""
+        // If definition is not provided, return an empty hex string
+        if (!definition) return hexString
+        // Iterating over the definitions
         for (const def of definition) {
           const { id, type } = def
+          // Get the processor for the given type
           const processor = processors[type]
-          // if the param is definined in the object
-
-          const v = params[id]
-          const val =
-            typeof v !== "undefined"
-              ? v
-              : typeof def.default !== "undefined"
-              ? def.default
-              : processor.random(def)
-          const serialized = processor.serialize(val, def)
-          bytes += serialized
+          // Get the param value, fall back to default or a random value
+          const paramValue = getParamValue(params[id], def, processor)
+          // Serialize the param value
+          const serializedParam = processor.serialize(paramValue, def)
+          // Concatenate serialized params
+          hexString += serializedParam
         }
-
-        return bytes
+        return hexString
       }
 
       // takes the parameters as bytes and outputs an object with the

--- a/project/public/index.html
+++ b/project/public/index.html
@@ -2,40 +2,60 @@
 <html>
   <head>
     <title>FXHASH project</title>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <script id="fxhash-snippet">
       //---- do not edit the following code (you can indent as you wish)
       let search = new URLSearchParams(window.location.search)
-      let alphabet = "123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ"
-      let b58dec = str=>[...str].reduce((p,c)=>p*alphabet.length+alphabet.indexOf(c)|0, 0)
+      let alphabet =
+        "123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ"
+      let b58dec = (str) =>
+        [...str].reduce(
+          (p, c) => (p * alphabet.length + alphabet.indexOf(c)) | 0,
+          0
+        )
       // make fxrand from hash
-      var fxhash = search.get('fxhash') || "oo" + Array(49).fill(0).map(_=>alphabet[(Math.random()*alphabet.length)|0]).join('')
+      var fxhash =
+        search.get("fxhash") ||
+        "oo" +
+          Array(49)
+            .fill(0)
+            .map((_) => alphabet[(Math.random() * alphabet.length) | 0])
+            .join("")
       let fxhashTrunc = fxhash.slice(2)
-      let regex = new RegExp(".{" + ((fxhash.length/4)|0) + "}", 'g')
-      let hashes = fxhashTrunc.match(regex).map(h => b58dec(h))
+      let regex = new RegExp(".{" + ((fxhash.length / 4) | 0) + "}", "g")
+      let hashes = fxhashTrunc.match(regex).map((h) => b58dec(h))
       let sfc32 = (a, b, c, d) => {
         return () => {
-          a |= 0; b |= 0; c |= 0; d |= 0
-          var t = (a + b | 0) + d | 0
-          d = d + 1 | 0
-          a = b ^ b >>> 9
-          b = c + (c << 3) | 0
-          c = c << 21 | c >>> 11
-          c = c + t | 0
+          a |= 0
+          b |= 0
+          c |= 0
+          d |= 0
+          var t = (((a + b) | 0) + d) | 0
+          d = (d + 1) | 0
+          a = b ^ (b >>> 9)
+          b = (c + (c << 3)) | 0
+          c = (c << 21) | (c >>> 11)
+          c = (c + t) | 0
           return (t >>> 0) / 4294967296
         }
       }
       var fxrand = sfc32(...hashes)
       // make fxrandminter from minter address
-      var fxminter = search.get('fxminter') || "tz1" + Array(33).fill(0).map(_=>alphabet[(Math.random()*alphabet.length)|0]).join('')
+      var fxminter =
+        search.get("fxminter") ||
+        "tz1" +
+          Array(33)
+            .fill(0)
+            .map((_) => alphabet[(Math.random() * alphabet.length) | 0])
+            .join("")
       let fxminterTrunc = fxminter.slice(3)
-      regex = new RegExp(".{" + ((fxminterTrunc.length/4)|0) + "}", 'g')
-      hashes = fxminterTrunc.match(regex).map(h => b58dec(h))
+      regex = new RegExp(".{" + ((fxminterTrunc.length / 4) | 0) + "}", "g")
+      hashes = fxminterTrunc.match(regex).map((h) => b58dec(h))
       var fxrandminter = sfc32(...hashes)
 
       // true if preview mode active, false otherwise
       // you can append preview=1 to the URL to simulate preview active
-      var isFxpreview = search.get('preview') === "1"
+      var isFxpreview = search.get("preview") === "1"
       // call this method to trigger the preview
       function fxpreview() {
         console.log("FXPREVIEW")
@@ -45,8 +65,27 @@
 
       // get the byte params from the URL
       const searchParams = search.get("fxparams")
-      let fxparams =  searchParams?.replace("0x", "") || searchParams
-      const debounce = (func, delay) => { let timeout; return (...args) => clearTimeout(timeout, timeout = setTimeout(() => func(...args), delay)); };
+      let initialInputBytes = searchParams?.replace("0x", "")
+      const debounce = (func, delay) => {
+        let t
+        let isFirstCall = true
+        return function (...args) {
+          const c = this
+          if (isFirstCall) {
+            func.apply(c, args)
+            isFirstCall = false
+          } else {
+            clearTimeout(t)
+            t = setTimeout(() => {
+              func.apply(c, args)
+            }, delay)
+          }
+        }
+      }
+
+      const _updateUrl = debounce((url) => {
+        window.history.pushState({ path: url.href }, "", url.href)
+      }, 300)
 
       const stringToHex = function (s) {
         let rtn = ""
@@ -67,7 +106,6 @@
         return hex
       }
 
-
       // the parameter processor, used to parse fxparams
       const processors = {
         number: {
@@ -84,7 +122,7 @@
             return view.getFloat64(0)
           },
           bytesLength: () => 8,
-          constrain: (value, definition) =>  {
+          constrain: (value, definition) => {
             let min = Number.MIN_SAFE_INTEGER
             if (typeof definition.options?.min !== "undefined")
               min = Number(definition.options.min)
@@ -94,7 +132,11 @@
             max = Math.min(max, Number.MAX_SAFE_INTEGER)
             min = Math.max(min, Number.MIN_SAFE_INTEGER)
             const v = Math.min(Math.max(value, min), max)
-            return v;
+            if (definition?.options?.step) {
+              const t = 1.0 / definition?.options?.step
+              return Math.round(v * t) / t
+            }
+            return v
           },
           random: (definition) => {
             let min = Number.MIN_SAFE_INTEGER
@@ -110,7 +152,7 @@
               const t = 1.0 / definition?.options?.step
               return Math.round(v * t) / t
             }
-            return v; 
+            return v
           },
         },
         bigint: {
@@ -178,23 +220,23 @@
           deserialize: (input) => input,
           bytesLength: () => 4,
           transform: (input) => {
-            const r = parseInt(input.slice(0,2), 16)
-            const g = parseInt(input.slice(2,4), 16)
-            const b = parseInt(input.slice(4,6), 16)
-            const a = parseInt(input.slice(6,8), 16)
+            const r = parseInt(input.slice(0, 2), 16)
+            const g = parseInt(input.slice(2, 4), 16)
+            const b = parseInt(input.slice(4, 6), 16)
+            const a = parseInt(input.slice(6, 8), 16)
             return {
               hex: {
-                rgb: '#' + input.slice(0,6),
-                rgba: '#' + input,
+                rgb: "#" + input.slice(0, 6),
+                rgba: "#" + input,
               },
               obj: {
-                rgb: { r, g, b},
-                rgba: { r, g, b, a},
+                rgb: { r, g, b },
+                rgba: { r, g, b, a },
               },
               arr: {
-                rgb: [r,g,b],
-                rgba: [r,g,b,a],
-              }
+                rgb: [r, g, b],
+                rgba: [r, g, b, a],
+              },
             }
           },
           constrain: (value, definition) => {
@@ -205,14 +247,9 @@
             `${[...Array(8)]
               .map(() => Math.floor(Math.random() * 16).toString(16))
               .join("")}`,
-          },
+        },
         string: {
           serialize: (input, def) => {
-            if (!def.version) {
-              let hex = stringToHex(input.substring(0, 64))
-              hex = hex.padEnd(64 * 4, "0")
-              return hex
-            }
             let max = 64
             if (typeof def.options?.maxLength !== "undefined")
               max = Number(def.options.maxLength)
@@ -232,7 +269,7 @@
           },
           bytesLength: (options) => {
             if (typeof options?.maxLength !== "undefined")
-                return Number(options.maxLength) * 2
+              return Number(options.maxLength) * 2
             return 64 * 2
           },
           constrain: (value, definition) => {
@@ -242,11 +279,11 @@
             let max = 64
             if (typeof definition.options?.maxLength !== "undefined")
               max = definition.options.maxLength
-            let v = value.slice(0, max);
+            let v = value.slice(0, max)
             if (v.length < min) {
               return v.padEnd(min)
             }
-            return v;
+            return v
           },
           random: (definition) => {
             let min = 0
@@ -263,18 +300,21 @@
         },
         select: {
           serialize: (input, def) => {
-          // find the index of the input in the array of options
-          return Math.min(255, def.options?.options?.indexOf(input) || 0)
-            .toString(16)
-            .padStart(2, "0")
+            // find the index of the input in the array of options
+            return Math.min(255, def.options?.options?.indexOf(input) || 0)
+              .toString(16)
+              .padStart(2, "0")
           },
           deserialize: (input, definition) => {
-            return definition.options.options[parseInt(input, 16)] || definition.default
+            return (
+              definition.options.options[parseInt(input, 16)] ||
+              definition.default
+            )
           },
           bytesLength: () => 1,
           constrain: (value, definition) => {
-            if(definition.options.options.includes(value)) {
-              return value;
+            if (definition.options.options.includes(value)) {
+              return value
             }
             return definition.options.options[0]
           },
@@ -284,15 +324,12 @@
             )
             return definition?.options?.options[index]
           },
-        }
+        },
       }
 
       // params are injected into the piece using the binary representation of the
       // numbers, to keep precision
-      function serializeParams(
-        params,
-        definition,
-      ) {
+      function serializeParams(params, definition) {
         // a single hex string will be used for all the params
         let bytes = ""
         if (!definition) return bytes
@@ -300,9 +337,7 @@
         // parameter as set on the UI
         for (const def of definition) {
           const { id, type } = def
-          const processor = processors[
-            type
-          ]
+          const processor = processors[type]
           // if the param is definined in the object
 
           const v = params[id]
@@ -325,34 +360,44 @@
         const params = {}
         for (const def of definition) {
           const processor = processors[def.type]
-          // if we don't have any parameters defined in the URL, set the 
+          // if we don't have any parameters defined in the URL, set the
           // default value and move on
           if (!bytes) {
             let v
             if (typeof def.default === "undefined") v = processor.random(def)
             else v = def.default
-            params[def.id] = processor.constrain?.(v, def) || v;
+            params[def.id] = processor.constrain?.(v, def) || v
             continue
           }
           // extract the length from the bytes & shift the initial bytes string
-          const valueBytes = bytes.substring(0, processor.bytesLength(def?.options) * 2)
+          const valueBytes = bytes.substring(
+            0,
+            processor.bytesLength(def?.options) * 2
+          )
           bytes = bytes.substring(processor.bytesLength(def?.options) * 2)
           // deserialize the bytes into the params
-          const value =  processor.deserialize(valueBytes, def)
-          params[def.id] = processor.constrain?.(value, def) || value;
+          const value = processor.deserialize(valueBytes, def)
+          params[def.id] = processor.constrain?.(value, def) || value
         }
         return params
       }
 
-      const transformParamValues = (values, definitions) => {
+      const processParam = (paramId, value, definitions, transformer) => {
+        const definition = definitions.find((d) => d.id === paramId)
+        const processor = processors[definition.type]
+        return processor[transformer]?.(value, definition) || value
+      }
+
+      const processParams = (values, definitions, transformer) => {
         const paramValues = {}
-        for (const def of definitions) {
-          const processor = processors[def.type]
-          const value = values[def.id]
+        for (const definition of definitions) {
+          const processor = processors[definition.type]
+          const value = values[definition.id]
           // deserialize the bytes into the params
-          paramValues[def.id] = processor.transform ? processor.transform(value) : value;
+          paramValues[definition.id] =
+            processor[transformer]?.(value, definition) || value
         }
-        return paramValues; 
+        return paramValues
       }
 
       window.$fx = {
@@ -365,31 +410,33 @@
         // where the parameter values are stored
         _paramValues: {},
         _listeners: {},
-        on: function(name, callback, onDone) {
-          if(!this._listeners[name]) {
+        on: function (name, callback, onDone) {
+          if (!this._listeners[name]) {
             this._listeners[name] = []
           }
           this._listeners[name].push([callback, onDone])
           return function removeListener() {
-            const index = this._listeners[eventName].findIndex(([c]) => c === callback);
+            const index = this._listeners[eventName].findIndex(
+              ([c]) => c === callback
+            )
             if (index > -1) {
-              this._listeners[eventName].splice(index, 1);
+              this._listeners[eventName].splice(index, 1)
             }
-          };
+          }
         },
-        call: async function(name, data) {
-          const results = [];
+        call: async function (name, data) {
+          const results = []
           if (this._listeners && this._listeners[name]) {
             for (const [callback, onDone] of this._listeners[name]) {
-              const result = callback(data);
+              const result = callback(data)
               if (result instanceof Promise) {
-                results.push([await result, onDone]);
+                results.push([await result, onDone])
               } else {
-                results.push([result, onDone]);
+                results.push([result, onDone])
               }
             }
           }
-          return results;
+          return results
         },
         hash: fxhash,
         rand: fxrand,
@@ -397,114 +444,143 @@
         minter: fxminter,
         randminter: fxrandminter,
 
-        inputBytes: fxparams,
+        inputBytes: initialInputBytes,
 
         preview: fxpreview,
         isPreview: isFxpreview,
-        params: function(definition) {
+        params: function (definition) {
           // todo: maybe do some validation on the dev side ?
           // or maybe not ?
           this._params = definition
-          this._rawValues = deserializeParams(fxparams, definition)
-          this._paramValues = transformParamValues(this._rawValues, definition)
+          this._rawValues = deserializeParams(initialInputBytes, definition)
+          this._paramValues = processParams(
+            this._rawValues,
+            definition,
+            "transform"
+          )
+          this._updateInputBytes()
         },
-        udpateParams: function(fxparams) {
-          this._rawValues = deserializeParams(fxparams, this._params)
-          this._paramValues = transformParamValues(this._rawValues, this._params)
-        },
-        updateParam: function(id, value) {
-          const definition = this._params.find(d => d.id === id)
+        _updateParam: function (id, value) {
+          const definition = this._params.find((d) => d.id === id)
           const processor = processors[definition.type]
           const v = processor.constrain?.(value, definition) || value
           this._rawValues[id] = v
           this._paramValues[id] = processor.transform?.(v) || v
           this._updateInputBytes()
         },
-        syncParam: function(id, value) {
-          this.updateParam(id, value)
-          parent.postMessage({
-            id: "fxhash_syncParam",
-            data: {
-              id,
-              value,
-            }
-          }, "*")
+        _updateParams: function (newValues) {
+          const constrained = processParams(
+            { ...this._rawValues, ...newValues },
+            this._params,
+            "constrain"
+          )
+          Object.keys(constrained).forEach((paramId) => {
+            this._rawValues[paramId] = constrained[paramId]
+          })
+          this._paramValues = processParams(
+            this._rawValues,
+            this._params,
+            "transform"
+          )
+          this._updateInputBytes()
         },
-        _updateParams: function({ bytes, id, value }) {
-          const handlers = await $fx.call("paramsUpdate", { bytes, value, id })
+        _receiveParamsUpdate: async function ({ bytes, id, value }) {
+          const handlers = await this.call("paramsUpdate", { bytes, value, id })
           handlers.forEach(([handled, onDone]) => {
             if (!handled) {
-              $fx.updateParam(id, value)
+              this._updateParam(id, value)
             }
             onDone?.()
           })
-        }
-        _updateInputBytes: function() {
-          const bytes = serializeParams(this._rawValues, this._params)
-          const urlObject = new URL(window.location.href)
-          urlObject.searchParams.set("fxparams", bytes)
-          fxparams = bytes
-          this.inputBytes = bytes
-          debounce(() => {
-            window.history.replaceState({ path: urlObject.href }, '', urlObject.href)
-          }, 300)
+          if (handlers.length === 0) this._updateParam(id, value)
         },
-        features: function(features) {
+        _updateInputBytes: function () {
+          const bytes = serializeParams(this._rawValues, this._params)
+          this.inputBytes = bytes
+          const url = new URL(window.location.href)
+          url.searchParams.set("fxparams", `0x${bytes}`)
+          _updateUrl(url)
+        },
+        features: function (features) {
           this._features = features
         },
-        getFeature: function(id) {
+        getFeature: function (id) {
           return this._features[id]
         },
-        getFeatures: function() {
+        getFeatures: function () {
           return this._features
         },
-        getParam: function(id) {
+        getParam: function (id) {
           return this._paramValues[id]
         },
-        getParams: function() {
+        getParams: function () {
           return this._paramValues
         },
-        getRawParam: function(id) {
+        getRawParam: function (id) {
           return this._rawValues[id]
         },
-        getRawParams: function() {
+        getRawParams: function () {
           return this._rawValues
         },
-        getDefinitions: function() {
-          return this._params;
+        getDefinitions: function () {
+          return this._params
         },
-        stringifyParams: function(params) {
+        stringifyParams: function (params) {
           return JSON.stringify(
             params,
             (key, value) => {
               if (typeof value === "bigint") return value.toString()
               return value
-            }, 
-            2,
+            },
+            2
+          )
+        },
+        syncParams: function (rawValues) {
+          this._updateParams(rawValues)
+          const constrained = Object.keys(rawValues).reduce((acc, paramId) => {
+            acc[paramId] = processParam(
+              paramId,
+              rawValues[paramId],
+              this._params,
+              "constrain"
+            )
+            return acc
+          }, {})
+          parent.postMessage(
+            {
+              id: "fxhash_syncParams",
+              data: {
+                params: constrained,
+              },
+            },
+            "*"
           )
         },
       }
 
       window.addEventListener("message", async (event) => {
         if (event.data === "fxhash_getInfo") {
-          parent.postMessage({
-            id: "fxhash_getInfo",
-            data: { 
-              version: window.$fx._version,
-              hash: window.$fx.hash,
-              features: window.$fx.getFeatures(),
-              params: {
-                definitions: window.$fx.getDefinitions(),
-                values: window.$fx.getRawParams(),
+          parent.postMessage(
+            {
+              id: "fxhash_getInfo",
+              data: {
+                version: window.$fx._version,
+                hash: window.$fx.hash,
+                features: window.$fx.getFeatures(),
+                params: {
+                  definitions: window.$fx.getDefinitions(),
+                  values: window.$fx.getRawParams(),
+                },
+                minter: window.$fx.minter,
+                settings: window.$fx._settings,
               },
-              minter: window.$fx.minter,
-              settings: window.$fx._settings,
             },
-          }, "*")
+            "*"
+          )
         }
-        if (event.data?.id === "fxhash_update") {
+        if (event.data?.id === "fxhash_updateParams") {
           const { bytes, value, id } = event.data.data
-          if (id) $fx._updateParams({bytes, value, id })
+          if (id) window.$fx._receiveParamsUpdate({ bytes, value, id })
         }
       })
       // END NEW
@@ -512,13 +588,11 @@
       //---- /do not edit the following code
     </script>
 
-    <link rel="stylesheet" href="./style.css">
+    <link rel="stylesheet" href="./style.css" />
 
     <!-- if you need to import js scripts do it here -->
   </head>
   <body>
-    
     <!-- WEBPACK will inject the bundle.js here -->
   </body>
 </html>
-

--- a/project/public/index.html
+++ b/project/public/index.html
@@ -481,7 +481,7 @@
           this._updateInputBytes()
         },
         _receiveParamsUpdate: async function ({ bytes, id, value }) {
-          const handlers = await this.call("paramsUpdate", { bytes, value, id })
+          const handlers = await this.call("updateParams", { bytes, value, id })
           handlers.forEach(([handled, onDone]) => {
             if (!handled) {
               this._updateParam(id, value)
@@ -533,7 +533,7 @@
         },
         emit: function (id, data) {
           switch (id) {
-            case "params":
+            case "updateParams":
               this._emitParams(data)
               break
             default:

--- a/project/public/index.html
+++ b/project/public/index.html
@@ -195,17 +195,11 @@
           },
         },
         boolean: {
-          serialize: (input) => {
-            return typeof input === "boolean"
-              ? input
-                ? "01"
-                : "00"
-              : typeof input === "string"
-              ? input === "true"
-                ? "01"
-                : "00"
-              : "00"
-          },
+          serialize: (input) =>
+            (typeof input === "boolean" && input) ||
+            (typeof input === "string" && input === "true")
+              ? "01"
+              : "00",
           // if value is "00" -> 0 -> false, otherwise we consider it's 1
           deserialize: (input) => {
             return input === "00" ? false : true

--- a/project/public/index.html
+++ b/project/public/index.html
@@ -480,15 +480,20 @@
           )
           this._updateInputBytes()
         },
-        _receiveParamsUpdate: async function ({ bytes, id, value }) {
-          const handlers = await this.call("updateParams", { bytes, value, id })
+        _receiveUpdateParams: async function ({ params }, onDefault) {
+          console.log(params)
+          const handlers = await this.call("updateParams", { params })
           handlers.forEach(([handled, onDone]) => {
             if (!handled) {
-              this._updateParam(id, value)
+              this._updateParams(params)
+              onDefault?.()
             }
             onDone?.()
           })
-          if (handlers.length === 0) this._updateParam(id, value)
+          if (handlers.length === 0) {
+            this._updateParams(params)
+            onDefault?.()
+          }
         },
         _updateInputBytes: function () {
           const bytes = serializeParams(this._rawValues, this._params)
@@ -541,26 +546,30 @@
               break
           }
         },
-        _emitParams: function (rawValues) {
-          this._updateParams(rawValues)
-          const constrained = Object.keys(rawValues).reduce((acc, paramId) => {
-            acc[paramId] = processParam(
-              paramId,
-              rawValues[paramId],
-              this._params,
-              "constrain"
-            )
-            return acc
-          }, {})
-          parent.postMessage(
-            {
-              id: "fxhash_emitParams",
-              data: {
-                params: constrained,
+        _emitParams: function (params) {
+          this._receiveUpdateParams({ params }, () => {
+            const constrained = Object.keys(params).reduce(
+              (acc, paramId) => {
+                acc[paramId] = processParam(
+                  paramId,
+                  params[paramId],
+                  this._params,
+                  "constrain"
+                )
+                return acc
               },
-            },
-            "*"
-          )
+              {}
+            )
+            parent.postMessage(
+              {
+                id: "fxhash_emitParams",
+                data: {
+                  params: constrained,
+                },
+              },
+              "*"
+            )
+          })
         },
       }
 
@@ -585,8 +594,8 @@
           )
         }
         if (event.data?.id === "fxhash_updateParams") {
-          const { bytes, value, id } = event.data.data
-          if (id) window.$fx._receiveParamsUpdate({ bytes, value, id })
+          const { params } = event.data.data
+          if (params) window.$fx._receiveUpdateParams({ params })
         }
       })
       // END NEW

--- a/project/public/index.html
+++ b/project/public/index.html
@@ -430,6 +430,15 @@
             }
           }, "*")
         },
+        _updateParams: function({ bytes, id, value }) {
+          const handlers = await $fx.call("paramsUpdate", { bytes, value, id })
+          handlers.forEach(([handled, onDone]) => {
+            if (!handled) {
+              $fx.updateParam(id, value)
+            }
+            onDone?.()
+          })
+        }
         _updateInputBytes: function() {
           const bytes = serializeParams(this._rawValues, this._params)
           const urlObject = new URL(window.location.href)
@@ -495,14 +504,7 @@
         }
         if (event.data?.id === "fxhash_update") {
           const { bytes, value, id } = event.data.data
-          if (!id) return
-          const handlers = await $fx.call("paramsUpdate", { bytes, value, id })
-          handlers.forEach(([handled, onDone]) => {
-            if (!handled) {
-              $fx.updateParam(id, value)
-            }
-            onDone?.()
-          })
+          if (id) $fx._updateParams({bytes, value, id })
         }
       })
       // END NEW

--- a/project/public/index.html
+++ b/project/public/index.html
@@ -42,9 +42,14 @@
         // window.dispatchEvent(new Event("fxhash-preview"))
         // setTimeout(() => fxpreview(), 500)
       }
+
+      function getParamsFromSearch() {
+        const searchParams = search.get("fxparams")
+        return searchParams?.replace("0x", "") || searchParams;
+      }
+
       // get the byte params from the URL
-      let fxparams = search.get('fxparams')
-      fxparams = fxparams ? fxparams.replace("0x", "") : fxparams
+      let fxparams;
 
       // the parameter processor, used to parse fxparams
       const processors = {
@@ -261,12 +266,39 @@
       window.$fx = {
         _version: "3.0.0",
         _processors: processors,
+        _flags: {},
         // where params def & features will be stored
         _params: undefined,
         _features: undefined,
         // where the parameter values are stored
         _paramValues: {},
-
+        _listeners: {},
+        on: function(name, callback) {
+          if(!this._listeners[name]) {
+            this._listeners[name] = []
+          }
+          this._listeners[name].push(callback)
+          return function removeListener() {
+            const index = this._listeners[eventName].indexOf(callback);
+            if (index > -1) {
+              this._listeners[eventName].splice(index, 1);
+            }
+          };
+        },
+        call: async function(name, data) {
+          const results = [];
+          if (this._listeners && this._listeners[name]) {
+            for (const callback of this._listeners[name]) {
+              const result = callback(data);
+              if (result instanceof Promise) {
+                results.push(await result);
+              } else {
+                results.push(result);
+              }
+            }
+          }
+          return results;
+        },
         hash: fxhash,
         rand: fxrand,
 
@@ -275,12 +307,19 @@
 
         preview: fxpreview,
         isPreview: isFxpreview,
-        params: function(definition) {
+        params: function(definition, options={}) {
           // todo: maybe do some validation on the dev side ?
           // or maybe not ?
+          const { withLiveParams=false } = options;
+          fxparams = getParamsFromSearch()
+          this._flags.withLiveParams = withLiveParams
           this._params = definition
           this._rawValues = deserializeParams(fxparams, definition)
           this._paramValues = transformParamValues(this._rawValues, definition)
+        },
+        udpateParams: function(fxparams) {
+          this._rawValues = deserializeParams(fxparams, this._params)
+          this._paramValues = transformParamValues(this._rawValues, this._params)
         },
         features: function(features) {
           this._features = features
@@ -315,10 +354,13 @@
             }, 
             2,
           )
-        }
-        
+        },
+        sendParams: function() {
+          
+        },
       }
-      window.addEventListener("message", (event) => {
+
+      window.addEventListener("message", async (event) => {
         if (event.data === "fxhash_getInfo") {
           parent.postMessage({
             id: "fxhash_getInfo",
@@ -331,8 +373,17 @@
                 values: window.$fx.getRawParams(),
               },
               minter: window.$fx.minter,
+              flags: window.$fx._flags,
             },
           }, "*")
+        }
+        if (event.data?.id === "fxhash_update") {
+          const { bytes, value, id, paramId } = event.data
+          const handled = await $fx.call("paramsUpdate", { bytes, value, paramId })
+          // do default thing when handlers didn't handle
+          if (handled.some(handle => !!handle)) {
+            $fx.udpateParams(bytes)
+          }
         }
       })
       // END NEW

--- a/project/public/index.html
+++ b/project/public/index.html
@@ -43,17 +43,39 @@
         // setTimeout(() => fxpreview(), 500)
       }
 
-      function getParamsFromSearch() {
-        const searchParams = search.get("fxparams")
-        return searchParams?.replace("0x", "") || searchParams;
+      // get the byte params from the URL
+      const searchParams = search.get("fxparams")
+      let fxparams =  searchParams?.replace("0x", "") || searchParams
+      const debounce = (func, delay) => { let timeout; return (...args) => clearTimeout(timeout, timeout = setTimeout(() => func(...args), delay)); };
+
+      const stringToHex = function (s) {
+        let rtn = ""
+        for (let i = 0; i < s.length; i++) {
+          rtn += s.charCodeAt(i).toString(16).padStart(4, "0")
+        }
+        return rtn
       }
 
-      // get the byte params from the URL
-      let fxparams;
+      function completeHexColor(hexCode) {
+        let hex = hexCode.replace("#", "")
+        if (hex.length === 6) {
+          hex = `${hex}ff`
+        }
+        if (hex.length === 3) {
+          hex = `${hex[0]}${hex[0]}${hex[1]}${hex[1]}${hex[2]}${hex[2]}ff`
+        }
+        return hex
+      }
+
 
       // the parameter processor, used to parse fxparams
       const processors = {
         number: {
+          serialize: (input) => {
+            const view = new DataView(new ArrayBuffer(8))
+            view.setFloat64(0, input)
+            return view.getBigUint64(0).toString(16).padStart(16, "0")
+          },
           deserialize: (input) => {
             const view = new DataView(new ArrayBuffer(8))
             for (let i = 0; i < 8; i++) {
@@ -92,6 +114,11 @@
           },
         },
         bigint: {
+          serialize: (input) => {
+            const view = new DataView(new ArrayBuffer(8))
+            view.setBigInt64(0, BigInt(input))
+            return view.getBigUint64(0).toString(16).padStart(16, "0")
+          },
           deserialize: (input) => {
             const view = new DataView(new ArrayBuffer(8))
             for (let i = 0; i < 8; i++) {
@@ -126,6 +153,17 @@
           },
         },
         boolean: {
+          serialize: (input) => {
+            return typeof input === "boolean"
+              ? input
+                ? "01"
+                : "00"
+              : typeof input === "string"
+              ? input === "true"
+                ? "01"
+                : "00"
+              : "00"
+          },
           // if value is "00" -> 0 -> false, otherwise we consider it's 1
           deserialize: (input) => {
             return input === "00" ? false : true
@@ -134,6 +172,9 @@
           random: () => Math.random() < 0.5,
         },
         color: {
+          serialize: (input) => {
+            return completeHexColor(input)
+          },
           deserialize: (input) => input,
           bytesLength: () => 4,
           transform: (input) => {
@@ -166,6 +207,19 @@
               .join("")}`,
           },
         string: {
+          serialize: (input, def) => {
+            if (!def.version) {
+              let hex = stringToHex(input.substring(0, 64))
+              hex = hex.padEnd(64 * 4, "0")
+              return hex
+            }
+            let max = 64
+            if (typeof def.options?.maxLength !== "undefined")
+              max = Number(def.options.maxLength)
+            let hex = stringToHex(input.substring(0, max))
+            hex = hex.padEnd(max * 4, "0")
+            return hex
+          },
           deserialize: (input) => {
             const hx = input.match(/.{1,4}/g) || []
             let rtn = ""
@@ -208,6 +262,12 @@
           },
         },
         select: {
+          serialize: (input, def) => {
+          // find the index of the input in the array of options
+          return Math.min(255, def.options?.options?.indexOf(input) || 0)
+            .toString(16)
+            .padStart(2, "0")
+          },
           deserialize: (input, definition) => {
             return definition.options.options[parseInt(input, 16)] || definition.default
           },
@@ -225,6 +285,38 @@
             return definition?.options?.options[index]
           },
         }
+      }
+
+      // params are injected into the piece using the binary representation of the
+      // numbers, to keep precision
+      function serializeParams(
+        params,
+        definition,
+      ) {
+        // a single hex string will be used for all the params
+        let bytes = ""
+        if (!definition) return bytes
+        // loop through each parameter from the definition to find the associated
+        // parameter as set on the UI
+        for (const def of definition) {
+          const { id, type } = def
+          const processor = processors[
+            type
+          ]
+          // if the param is definined in the object
+
+          const v = params[id]
+          const val =
+            typeof v !== "undefined"
+              ? v
+              : typeof def.default !== "undefined"
+              ? def.default
+              : processor.random(def)
+          const serialized = processor.serialize(val, def)
+          bytes += serialized
+        }
+
+        return bytes
       }
 
       // takes the parameters as bytes and outputs an object with the
@@ -266,20 +358,20 @@
       window.$fx = {
         _version: "3.0.0",
         _processors: processors,
-        _flags: {},
+        _settings: {},
         // where params def & features will be stored
         _params: undefined,
         _features: undefined,
         // where the parameter values are stored
         _paramValues: {},
         _listeners: {},
-        on: function(name, callback) {
+        on: function(name, callback, onDone) {
           if(!this._listeners[name]) {
             this._listeners[name] = []
           }
-          this._listeners[name].push(callback)
+          this._listeners[name].push([callback, onDone])
           return function removeListener() {
-            const index = this._listeners[eventName].indexOf(callback);
+            const index = this._listeners[eventName].findIndex(([c]) => c === callback);
             if (index > -1) {
               this._listeners[eventName].splice(index, 1);
             }
@@ -288,12 +380,12 @@
         call: async function(name, data) {
           const results = [];
           if (this._listeners && this._listeners[name]) {
-            for (const callback of this._listeners[name]) {
+            for (const [callback, onDone] of this._listeners[name]) {
               const result = callback(data);
               if (result instanceof Promise) {
-                results.push(await result);
+                results.push([await result, onDone]);
               } else {
-                results.push(result);
+                results.push([result, onDone]);
               }
             }
           }
@@ -305,14 +397,13 @@
         minter: fxminter,
         randminter: fxrandminter,
 
+        inputBytes: fxparams,
+
         preview: fxpreview,
         isPreview: isFxpreview,
-        params: function(definition, options={}) {
+        params: function(definition) {
           // todo: maybe do some validation on the dev side ?
           // or maybe not ?
-          const { withLiveParams=false } = options;
-          fxparams = getParamsFromSearch()
-          this._flags.withLiveParams = withLiveParams
           this._params = definition
           this._rawValues = deserializeParams(fxparams, definition)
           this._paramValues = transformParamValues(this._rawValues, definition)
@@ -320,6 +411,34 @@
         udpateParams: function(fxparams) {
           this._rawValues = deserializeParams(fxparams, this._params)
           this._paramValues = transformParamValues(this._rawValues, this._params)
+        },
+        updateParam: function(id, value) {
+          const definition = this._params.find(d => d.id === id)
+          const processor = processors[definition.type]
+          const v = processor.constrain?.(value, definition) || value
+          this._rawValues[id] = v
+          this._paramValues[id] = processor.transform?.(v) || v
+          this._updateInputBytes()
+        },
+        syncParam: function(id, value) {
+          this.updateParam(id, value)
+          parent.postMessage({
+            id: "fxhash_syncParam",
+            data: {
+              id,
+              value,
+            }
+          }, "*")
+        },
+        _updateInputBytes: function() {
+          const bytes = serializeParams(this._rawValues, this._params)
+          const urlObject = new URL(window.location.href)
+          urlObject.searchParams.set("fxparams", bytes)
+          fxparams = bytes
+          this.inputBytes = bytes
+          debounce(() => {
+            window.history.replaceState({ path: urlObject.href }, '', urlObject.href)
+          }, 300)
         },
         features: function(features) {
           this._features = features
@@ -355,9 +474,6 @@
             2,
           )
         },
-        sendParams: function() {
-          
-        },
       }
 
       window.addEventListener("message", async (event) => {
@@ -373,17 +489,20 @@
                 values: window.$fx.getRawParams(),
               },
               minter: window.$fx.minter,
-              flags: window.$fx._flags,
+              settings: window.$fx._settings,
             },
           }, "*")
         }
         if (event.data?.id === "fxhash_update") {
-          const { bytes, value, id, paramId } = event.data
-          const handled = await $fx.call("paramsUpdate", { bytes, value, paramId })
-          // do default thing when handlers didn't handle
-          if (handled.some(handle => !!handle)) {
-            $fx.udpateParams(bytes)
-          }
+          const { bytes, value, id } = event.data.data
+          if (!id) return
+          const handlers = await $fx.call("paramsUpdate", { bytes, value, id })
+          handlers.forEach(([handled, onDone]) => {
+            if (!handled) {
+              $fx.updateParam(id, value)
+            }
+            onDone?.()
+          })
         }
       })
       // END NEW

--- a/project/public/index.html
+++ b/project/public/index.html
@@ -535,7 +535,17 @@
             2
           )
         },
-        syncParams: function (rawValues) {
+        emit: function (id, data) {
+          switch (id) {
+            case "params":
+              this._emitParams(data)
+              break
+            default:
+              console.log("$fx.emit called with unknown id:", id)
+              break
+          }
+        },
+        _emitParams: function (rawValues) {
           this._updateParams(rawValues)
           const constrained = Object.keys(rawValues).reduce((acc, paramId) => {
             acc[paramId] = processParam(
@@ -548,7 +558,7 @@
           }, {})
           parent.postMessage(
             {
-              id: "fxhash_syncParams",
+              id: "fxhash_emitParams",
               data: {
                 params: constrained,
               },

--- a/project/src/index.js
+++ b/project/src/index.js
@@ -1,79 +1,78 @@
 // console.log(fxhash);
 // console.log(fxrand());
 
-const sp = new URLSearchParams(window.location.search);
+const sp = new URLSearchParams(window.location.search)
 //  console.log(sp);
 
 // this is how to define parameters
-$fx.params(
-  [
-    {
-      id: "number_id",
-      name: "A number/float64",
-      type: "number",
-      //default: Math.PI,
-      options: {
-        min: 1,
-        max: 10,
-        step: 0.00000000000001,
-      },
+$fx.params([
+  {
+    id: "number_id",
+    name: "A number/float64",
+    type: "number",
+    //default: Math.PI,
+    isLive: true,
+    options: {
+      min: 1,
+      max: 10,
+      step: 0.00000000000001,
     },
+  },
 
-    {
-      id: "bigint_id",
-      name: "A bigint",
-      type: "bigint",
-      //default: BigInt(Number.MAX_SAFE_INTEGER * 2),
-      options: {
-        min: Number.MIN_SAFE_INTEGER * 4,
-        max: Number.MAX_SAFE_INTEGER * 4,
-        step: 1,
-      },
+  {
+    id: "bigint_id",
+    name: "A bigint",
+    type: "bigint",
+    //default: BigInt(Number.MAX_SAFE_INTEGER * 2),
+    options: {
+      min: Number.MIN_SAFE_INTEGER * 4,
+      max: Number.MAX_SAFE_INTEGER * 4,
+      step: 1,
     },
-    {
-      id: "string_id_long",
-      name: "A string long",
-      type: "string",
-      //default: "hello",
-      options: {
-        minLength: 1,
-        maxLength: 512,
-      },
+  },
+  {
+    id: "string_id_long",
+    name: "A string long",
+    type: "string",
+    //default: "hello",
+    options: {
+      minLength: 1,
+      maxLength: 512,
     },
-    {
-      id: "select_id",
-      name: "A selection",
-      type: "select",
-      //default: "pear",
-      options: {
-        options: ["apple", "orange", "pear"],
-      },
+  },
+  {
+    id: "select_id",
+    name: "A selection",
+    type: "select",
+    //default: "pear",
+    options: {
+      options: ["apple", "orange", "pear"],
     },
-    {
-      id: "color_id",
-      name: "A color",
-      type: "color",
-      //default: "ff0000",
+  },
+  {
+    id: "color_id",
+    name: "A color",
+    type: "color",
+    isLive: true,
+    //default: "ff0000",
+  },
+  {
+    id: "boolean_id",
+    name: "A boolean",
+    type: "boolean",
+    //default: true,
+  },
+  {
+    id: "string_id",
+    name: "A string",
+    type: "string",
+    //default: "hello",
+    options: {
+      minLength: 1,
+      maxLength: 512,
     },
-    {
-      id: "boolean_id",
-      name: "A boolean",
-      type: "boolean",
-      //default: true,
-    },
-    {
-      id: "string_id",
-      name: "A string",
-      type: "string",
-      //default: "hello",
-      options: {
-        minLength: 1,
-        maxLength: 512,
-      },
-    },
-  ],
-  { withLiveParams: true }
-);
+  },
+])
 
 // this is how features can be defined
 $fx.features({
@@ -81,7 +80,7 @@ $fx.features({
   "A random boolean": $fx.rand() > 0.5,
   "A random string": ["A", "B", "C", "D"].at(Math.floor($fx.rand() * 4)),
   "Feature from params, its a number": $fx.getParam("number_id"),
-});
+})
 
 function main() {
   // log the parameters, for debugging purposes, artists won't have to do that
@@ -99,32 +98,51 @@ function main() {
   // console.log("Single transformed value:");
   // console.log($fx.getParam("color_id"));
 
+  const getContrastTextColor = (backgroundColor) =>
+    ((parseInt(backgroundColor, 16) >> 16) & 0xff) > 0xaa
+      ? "#000000"
+      : "#ffffff"
+
+  const bgcolor = $fx.getParam("color_id").hex.rgba
+  const textcolor = getContrastTextColor(bgcolor.replace("#", ""))
+
   // update the document based on the parameters
-  document.body.style.background = $fx.getParam("color_id").hex.rgba;
+  document.body.style.background = bgcolor
   document.body.innerHTML = `
-  <p>
-  url: ${window.location.href}
-  </p>
-  <p>
-  hash: ${$fx.hash}
-  </p>
-  <p>
-  params:
-  </p>
-  <pre>
-  ${$fx.stringifyParams($fx.getRawParams())}
-  </pre>
-  <pre style="color: white;">
-  ${$fx.stringifyParams($fx.getRawParams())}
-  </pre>
-  `;
+  <div style="color: ${textcolor};">
+    <p>
+    url: ${window.location.href}
+    </p>
+    <p>
+    hash: ${$fx.hash}
+    </p>
+    <p>
+    minter: ${$fx.minter}
+    </p>
+    <p>
+    inputBytes: ${$fx.inputBytes}
+    </p>
+    <p>
+    params:
+    </p>
+    <pre>
+    ${$fx.stringifyParams($fx.getRawParams())}
+    </pre>
+  <div>
+  `
+  const btn = document.createElement("button")
+  btn.textContent = "Sync number_id"
+  btn.addEventListener("click", () => {
+    $fx.syncParam("number_id", Math.random() * 9 + 1)
+    main()
+  })
+  document.body.appendChild(btn)
 }
 
-main();
+main()
 
 $fx.on(
   "paramsUpdate",
-  () => new Promise((resolve) => {
-    resolve(main)
-  })
-);
+  () => false,
+  () => main()
+)

--- a/project/src/index.js
+++ b/project/src/index.js
@@ -11,11 +11,11 @@ $fx.params([
     name: "A number/float64",
     type: "number",
     //default: Math.PI,
-    isLive: true,
+    update: "sync",
     options: {
       min: 1,
       max: 10,
-      step: 0.00000000000001,
+      step: 0.0001,
     },
   },
 
@@ -53,7 +53,7 @@ $fx.params([
     id: "color_id",
     name: "A color",
     type: "color",
-    isLive: true,
+    update: "sync",
     //default: "ff0000",
   },
   {
@@ -111,9 +111,6 @@ function main() {
   document.body.innerHTML = `
   <div style="color: ${textcolor};">
     <p>
-    url: ${window.location.href}
-    </p>
-    <p>
     hash: ${$fx.hash}
     </p>
     <p>
@@ -133,7 +130,7 @@ function main() {
   const btn = document.createElement("button")
   btn.textContent = "Sync number_id"
   btn.addEventListener("click", () => {
-    $fx.syncParam("number_id", Math.random() * 9 + 1)
+    $fx.syncParams({ number_id: Math.random() * 9 + 1 })
     main()
   })
   document.body.appendChild(btn)

--- a/project/src/index.js
+++ b/project/src/index.js
@@ -143,6 +143,9 @@ main()
 
 $fx.on(
   "paramsUpdate",
-  () => false,
+  ({ bytes, id, value }) => {
+    if (value === 5 && id === "number_id") return true
+    return false
+  },
   () => main()
 )

--- a/project/src/index.js
+++ b/project/src/index.js
@@ -130,7 +130,7 @@ function main() {
   const btn = document.createElement("button")
   btn.textContent = "Sync number_id"
   btn.addEventListener("click", () => {
-    $fx.emit("params", { number_id: Math.random() * 9 + 1 })
+    $fx.emit("updateParams", { number_id: Math.random() * 9 + 1 })
     main()
   })
   document.body.appendChild(btn)
@@ -139,7 +139,7 @@ function main() {
 main()
 
 $fx.on(
-  "paramsUpdate",
+  "updateParams",
   ({ bytes, id, value }) => {
     if (value === 5 && id === "number_id") return true
     return false

--- a/project/src/index.js
+++ b/project/src/index.js
@@ -1,116 +1,130 @@
-console.log(fxhash)
-console.log(fxrand())
+// console.log(fxhash);
+// console.log(fxrand());
 
 const sp = new URLSearchParams(window.location.search);
-console.log(sp);
+//  console.log(sp);
 
 // this is how to define parameters
-$fx.params([
-  {
-    id: "number_id",
-    name: "A number/float64",
-    type: "number",
-    //default: Math.PI,
-    options: {
-      min: 1,
-      max: 10,
-      step: 0.00000000000001,
+$fx.params(
+  [
+    {
+      id: "number_id",
+      name: "A number/float64",
+      type: "number",
+      //default: Math.PI,
+      options: {
+        min: 1,
+        max: 10,
+        step: 0.00000000000001,
+      },
     },
-  },
-  
-  {
-    id: "bigint_id",
-    name: "A bigint",
-    type: "bigint",
-    //default: BigInt(Number.MAX_SAFE_INTEGER * 2),
-    options: {
-      min: Number.MIN_SAFE_INTEGER * 4,
-      max: Number.MAX_SAFE_INTEGER * 4,
-      step: 1,
+
+    {
+      id: "bigint_id",
+      name: "A bigint",
+      type: "bigint",
+      //default: BigInt(Number.MAX_SAFE_INTEGER * 2),
+      options: {
+        min: Number.MIN_SAFE_INTEGER * 4,
+        max: Number.MAX_SAFE_INTEGER * 4,
+        step: 1,
+      },
     },
-  },
-  {
-    id: "string_id_long",
-    name: "A string long",
-    type: "string",
-    //default: "hello",
-    options: {
-      minLength: 1,
-      maxLength: 512
-    }
-  },
-  {
-    id: "select_id",
-    name: "A selection",
-    type: "select",
-    //default: "pear",
-    options: {
-      options: ["apple", "orange", "pear"],
-    }
-  },
-  {
-    id: "color_id",
-    name: "A color",
-    type: "color",
-    //default: "ff0000",
-  },
-  {
-    id: "boolean_id",
-    name: "A boolean",
-    type: "boolean",
-    //default: true,
-  },
-  {
-    id: "string_id",
-    name: "A string",
-    type: "string",
-    //default: "hello",
-    options: {
-      minLength: 1,
-      maxLength: 512
-    }
-  },
-]);
+    {
+      id: "string_id_long",
+      name: "A string long",
+      type: "string",
+      //default: "hello",
+      options: {
+        minLength: 1,
+        maxLength: 512,
+      },
+    },
+    {
+      id: "select_id",
+      name: "A selection",
+      type: "select",
+      //default: "pear",
+      options: {
+        options: ["apple", "orange", "pear"],
+      },
+    },
+    {
+      id: "color_id",
+      name: "A color",
+      type: "color",
+      //default: "ff0000",
+    },
+    {
+      id: "boolean_id",
+      name: "A boolean",
+      type: "boolean",
+      //default: true,
+    },
+    {
+      id: "string_id",
+      name: "A string",
+      type: "string",
+      //default: "hello",
+      options: {
+        minLength: 1,
+        maxLength: 512,
+      },
+    },
+  ],
+  { withLiveParams: true }
+);
 
 // this is how features can be defined
 $fx.features({
   "A random feature": Math.floor($fx.rand() * 10),
   "A random boolean": $fx.rand() > 0.5,
-  "A random string": ["A", "B", "C", "D"].at(Math.floor($fx.rand()*4)),
+  "A random string": ["A", "B", "C", "D"].at(Math.floor($fx.rand() * 4)),
   "Feature from params, its a number": $fx.getParam("number_id"),
-})
+});
 
-// log the parameters, for debugging purposes, artists won't have to do that
-console.log("Current param values:")
-// Raw deserialize param values 
-console.log($fx.getRawParams())
-// Added addtional transformation to the parameter for easier usage
-// e.g. color.hex.rgba, color.obj.rgba.r, color.arr.rgb[0] 
-console.log($fx.getParams())
+function main() {
+  // log the parameters, for debugging purposes, artists won't have to do that
+  // console.log("Current param values:");
+  // // Raw deserialize param values
+  // console.log($fx.getRawParams());
+  // // Added addtional transformation to the parameter for easier usage
+  // // e.g. color.hex.rgba, color.obj.rgba.r, color.arr.rgb[0]
+  // console.log($fx.getParams());
 
-// how to read a single raw parameter
-console.log("Single raw value:")
-console.log($fx.getRawParam("color_id"));
-// how to read a single transformed parameter
-console.log("Single transformed value:")
-console.log($fx.getParam("color_id"));
+  // // how to read a single raw parameter
+  // console.log("Single raw value:");
+  // console.log($fx.getRawParam("color_id"));
+  // // how to read a single transformed parameter
+  // console.log("Single transformed value:");
+  // console.log($fx.getParam("color_id"));
 
-// update the document based on the parameters
-document.body.style.background = $fx.getParam("color_id").hex.rgba
-document.body.innerHTML = `
-<p>
-url: ${window.location.href}
-</p>
-<p>
-hash: ${$fx.hash}
-</p>
-<p>
-params:
-</p>
-<pre>
-${$fx.stringifyParams($fx.getRawParams())}
-</pre>
-<pre style="color: white;">
-${$fx.stringifyParams($fx.getRawParams())}
-</pre>
-`
+  // update the document based on the parameters
+  document.body.style.background = $fx.getParam("color_id").hex.rgba;
+  document.body.innerHTML = `
+  <p>
+  url: ${window.location.href}
+  </p>
+  <p>
+  hash: ${$fx.hash}
+  </p>
+  <p>
+  params:
+  </p>
+  <pre>
+  ${$fx.stringifyParams($fx.getRawParams())}
+  </pre>
+  <pre style="color: white;">
+  ${$fx.stringifyParams($fx.getRawParams())}
+  </pre>
+  `;
+}
+
+main();
+
+$fx.on(
+  "paramsUpdate",
+  () => new Promise((resolve) => {
+    resolve(main)
+  })
+);

--- a/project/src/index.js
+++ b/project/src/index.js
@@ -130,7 +130,7 @@ function main() {
   const btn = document.createElement("button")
   btn.textContent = "Sync number_id"
   btn.addEventListener("click", () => {
-    $fx.syncParams({ number_id: Math.random() * 9 + 1 })
+    $fx.emit("params", { number_id: Math.random() * 9 + 1 })
     main()
   })
   document.body.appendChild(btn)


### PR DESCRIPTION
__________________
> Use this branch with the fxlens companion branch: https://github.com/fxhash/fxlens/pull/19
__________________

This PR adds __fx(params) update modes__ and __emitting data from artwork to the parent__ with controller features.

# fx(params) update modes

Live params can be enabled on a per param basis. To mark a parameter as live parameter you must specify the update mode of the param by setting the `update` flag on the parameter definition. The default update mode is `"page-reload"` which describes the already known behaviour of updating the artwork by performing a full page-load.

```js
{
  id: "number_id",
  name: "A number/float64",
  type: "number",
  update: "sync", // <-- new update property
},
```

Parameters with update mode `"sync"` will be updated through the controllers without refreshing the artwork (iframe src). If your artwork is already running in some kind of draw loop (e.g. via `requestAnimationFrame`), you will already receive the live updates, because the updates are received in the background and the parameters are automatically updated on all places. If you want to only re-render you artwork when the update event was received and/or introduce some custom event handling you can use the new event listeners described in the next section. 

### Advanced configuration via event listeners

An event system was implemented. Artists can now subscribe to specific events in the pipeline, to trigger effects and override default behaviours by using the `$fx.on()` function. 

#### `$fx.on()`
```ts
$fx.on(
  // the id of the event to subscribe to
  eventId: string,
  // the callback return true to opt out of default behaviour
  handler: (bytes: string, id: string, value: any) => boolean | Promise<boolean>, 
  // callback when event is done (e.g. after default behaviour)
  onDone: () => void
)
```
To subscribe to the parameter updates event you have to add a listener to the `updateParams` event. The following code snippet subscribes to the `updateParams` event and prevents the parameters to be updated when the updated parameter is `number_id` and the value is `5`. Finally we call the main function that re-renders the artwork. This will prevent the value of the `number_id` live param param to ever be set to 5 through the controllers.

```js
function main() {
  // render artwork
}

$fx.on(
  "updateParams",
  (bytes: string, id: string, value: any) => {
    if  (id === "number_id" && value == 5) return true;
    return false;
  },
  () => main(),
)
```

# Emitting data from artwork to the parent

A new function called `$fx.emit` allows to emit data to the parent of the artwork. This means you can e.g. update the controllers of the minting interface from the artwork's code directly. This feature solves the "Pensado a mano"-usecase 🐰. It allows an artist to create custom interfaces on their artworks or receive any kind of input from collectors and emit those inputs back to the ui of the parent. 

#### `$fx.emit()`
```ts
$fx.emit(
  // the id of the emission event
  id: string,
  // the data send through the emission
  data: any,
)
```

## Emitting param updates

For now there is only one valid event id to be used with the `$fx.emit()` function: `"updateParams"`.
Same as with the "sync" update mode for parameters, it is depending on the artwork, if you need to call your render function after `$fx.emit()` was called. To sync the `number_id` parameter with a random value upon button click you could use the following code snippet. 

```js
const btn = document.createElement("button")
btn.textContent = "Sync number_id"
btn.addEventListener("click", () => {
  $fx.emit("updateParams", { number_id: Math.random() * 9 + 1 })
  // call your render function if you don't render in a loop
  main()
})
```

Of course the `updateParams` emission is part of the `updateParams` data-flow. This means by subscribing to the `$fx.on("updateParams")` event you are able to cancel the emission via the event handler. 


# TODO

- context variable 
- conditional params
- param descriptions
- seed param
- byte param
- cleanup + integrate toxi's improvements