### PR TITLE
Adds $fx.emit + $fx.iteration

### DIFF
--- a/project/public/index.html
+++ b/project/public/index.html
@@ -365,7 +365,7 @@
       }
 
       window.$fx = {
-        _version: "3.1.0",
+        _version: "3.2.0",
         _processors: processors,
         // where params def & features will be stored
         _params: undefined,

--- a/project/public/index.html
+++ b/project/public/index.html
@@ -412,8 +412,7 @@
           this.inputBytes = bytes
         },
         _emitParams: function (newRawValues) {
-          this._receiveUpdateParams(newRawValues, () => {
-            const constrained = Object.keys(newRawValues).reduce(
+          const constrainedValues = Object.keys(newRawValues).reduce(
               (acc, paramId) => {
                 acc[paramId] = processParam(
                   paramId,
@@ -425,11 +424,12 @@
               },
               {}
             )
+          this._receiveUpdateParams(constrainedValues, () => {
             parent.postMessage(
               {
-                id: "fxhash_emitParams",
+                id: "fxhash_emit:params:update",
                 data: {
-                  params: constrained,
+                  params: constrainedValues,
                 },
               },
               "*"
@@ -521,7 +521,7 @@
         },
         emit: function (id, data) {
           switch (id) {
-            case "updateParams":
+            case "params:update":
               this._emitParams(data)
               break
             default:

--- a/project/public/index.html
+++ b/project/public/index.html
@@ -422,6 +422,31 @@
           url.searchParams.set("fxparams", `0x${bytes}`)
           _updateUrl(url)
         },
+        _emitParams: function (newRawValues) {
+          this._receiveUpdateParams(newRawValues, () => {
+            const constrained = Object.keys(newRawValues).reduce(
+              (acc, paramId) => {
+                acc[paramId] = processParam(
+                  paramId,
+                  newRawValues[paramId],
+                  this._params,
+                  "constrain"
+                )
+                return acc
+              },
+              {}
+            )
+            parent.postMessage(
+              {
+                id: "fxhash_emitParams",
+                data: {
+                  params: constrained,
+                },
+              },
+              "*"
+            )
+          })
+        },
         hash: fxhash,
         rand: fxrand,
 
@@ -501,6 +526,16 @@
             }
           }
           return results
+        },
+        emit: function (id, data) {
+          switch (id) {
+            case "updateParams":
+              this._emitParams(data)
+              break
+            default:
+              console.log("$fx.emit called with unknown id:", id)
+              break
+          }
         },
       }
       window.addEventListener("message", (event) => {

--- a/project/public/index.html
+++ b/project/public/index.html
@@ -43,12 +43,57 @@
         // setTimeout(() => fxpreview(), 500)
       }
       // get the byte params from the URL
-      let fxparams = search.get('fxparams')
-      fxparams = fxparams ? fxparams.replace("0x", "") : fxparams
+      // get the byte params from the URL
+      const searchParams = search.get("fxparams")
+      let initialInputBytes = searchParams?.replace("0x", "")
+      const debounce = (func, delay) => {
+        let t
+        let isFirstCall = true
+        return function (...args) {
+          const c = this
+          if (isFirstCall) {
+            func.apply(c, args)
+            isFirstCall = false
+          } else {
+            clearTimeout(t)
+            t = setTimeout(() => {
+              func.apply(c, args)
+            }, delay)
+          }
+        }
+      }
+
+      const _updateUrl = debounce((url) => {
+        window.history.pushState({ path: url.href }, "", url.href)
+      }, 300)
+
+      const stringToHex = function (s) {
+        let rtn = ""
+        for (let i = 0; i < s.length; i++) {
+          rtn += s.charCodeAt(i).toString(16).padStart(4, "0")
+        }
+        return rtn
+      }
+
+      function completeHexColor(hexCode) {
+        let hex = hexCode.replace("#", "")
+        if (hex.length === 6) {
+          hex = `${hex}ff`
+        }
+        if (hex.length === 3) {
+          hex = `${hex[0]}${hex[0]}${hex[1]}${hex[1]}${hex[2]}${hex[2]}ff`
+        }
+        return hex
+      }
 
       // the parameter processor, used to parse fxparams
       const processors = {
         number: {
+          serialize: (input) => {
+            const view = new DataView(new ArrayBuffer(8))
+            view.setFloat64(0, input)
+            return view.getBigUint64(0).toString(16).padStart(16, "0")
+          },
           deserialize: (input) => {
             const view = new DataView(new ArrayBuffer(8))
             for (let i = 0; i < 8; i++) {
@@ -57,7 +102,7 @@
             return view.getFloat64(0)
           },
           bytesLength: () => 8,
-          constrain: (value, definition) =>  {
+          constrain: (value, definition) => {
             let min = Number.MIN_SAFE_INTEGER
             if (typeof definition.options?.min !== "undefined")
               min = Number(definition.options.min)
@@ -67,7 +112,11 @@
             max = Math.min(max, Number.MAX_SAFE_INTEGER)
             min = Math.max(min, Number.MIN_SAFE_INTEGER)
             const v = Math.min(Math.max(value, min), max)
-            return v;
+            if (definition?.options?.step) {
+              const t = 1.0 / definition?.options?.step
+              return Math.round(v * t) / t
+            }
+            return v
           },
           random: (definition) => {
             let min = Number.MIN_SAFE_INTEGER
@@ -83,10 +132,15 @@
               const t = 1.0 / definition?.options?.step
               return Math.round(v * t) / t
             }
-            return v; 
+            return v
           },
         },
         bigint: {
+          serialize: (input) => {
+            const view = new DataView(new ArrayBuffer(8))
+            view.setBigInt64(0, BigInt(input))
+            return view.getBigUint64(0).toString(16).padStart(16, "0")
+          },
           deserialize: (input) => {
             const view = new DataView(new ArrayBuffer(8))
             for (let i = 0; i < 8; i++) {
@@ -121,6 +175,11 @@
           },
         },
         boolean: {
+          serialize: (input) =>
+            (typeof input === "boolean" && input) ||
+            (typeof input === "string" && input === "true")
+              ? "01"
+              : "00",
           // if value is "00" -> 0 -> false, otherwise we consider it's 1
           deserialize: (input) => {
             return input === "00" ? false : true
@@ -129,26 +188,29 @@
           random: () => Math.random() < 0.5,
         },
         color: {
+          serialize: (input) => {
+            return completeHexColor(input)
+          },
           deserialize: (input) => input,
           bytesLength: () => 4,
           transform: (input) => {
-            const r = parseInt(input.slice(0,2), 16)
-            const g = parseInt(input.slice(2,4), 16)
-            const b = parseInt(input.slice(4,6), 16)
-            const a = parseInt(input.slice(6,8), 16)
+            const r = parseInt(input.slice(0, 2), 16)
+            const g = parseInt(input.slice(2, 4), 16)
+            const b = parseInt(input.slice(4, 6), 16)
+            const a = parseInt(input.slice(6, 8), 16)
             return {
               hex: {
-                rgb: '#' + input.slice(0,6),
-                rgba: '#' + input,
+                rgb: "#" + input.slice(0, 6),
+                rgba: "#" + input,
               },
               obj: {
-                rgb: { r, g, b},
-                rgba: { r, g, b, a},
+                rgb: { r, g, b },
+                rgba: { r, g, b, a },
               },
               arr: {
-                rgb: [r,g,b],
-                rgba: [r,g,b,a],
-              }
+                rgb: [r, g, b],
+                rgba: [r, g, b, a],
+              },
             }
           },
           constrain: (value, definition) => {
@@ -159,8 +221,16 @@
             `${[...Array(8)]
               .map(() => Math.floor(Math.random() * 16).toString(16))
               .join("")}`,
-          },
+        },
         string: {
+          serialize: (input, def) => {
+            let max = 64
+            if (typeof def.options?.maxLength !== "undefined")
+              max = Number(def.options.maxLength)
+            let hex = stringToHex(input.substring(0, max))
+            hex = hex.padEnd(max * 4, "0")
+            return hex
+          },
           deserialize: (input) => {
             const hx = input.match(/.{1,4}/g) || []
             let rtn = ""
@@ -173,7 +243,7 @@
           },
           bytesLength: (options) => {
             if (typeof options?.maxLength !== "undefined")
-                return Number(options.maxLength) * 2
+              return Number(options.maxLength) * 2
             return 64 * 2
           },
           constrain: (value, definition) => {
@@ -183,11 +253,11 @@
             let max = 64
             if (typeof definition.options?.maxLength !== "undefined")
               max = definition.options.maxLength
-            let v = value.slice(0, max);
+            let v = value.slice(0, max)
             if (v.length < min) {
               return v.padEnd(min)
             }
-            return v;
+            return v
           },
           random: (definition) => {
             let min = 0
@@ -203,13 +273,22 @@
           },
         },
         select: {
+          serialize: (input, def) => {
+            // find the index of the input in the array of options
+            return Math.min(255, def.options?.options?.indexOf(input) || 0)
+              .toString(16)
+              .padStart(2, "0")
+          },
           deserialize: (input, definition) => {
-            return definition.options.options[parseInt(input, 16)] || definition.default
+            return (
+              definition.options.options[parseInt(input, 16)] ||
+              definition.default
+            )
           },
           bytesLength: () => 1,
           constrain: (value, definition) => {
-            if(definition.options.options.includes(value)) {
-              return value;
+            if (definition.options.options.includes(value)) {
+              return value
             }
             return definition.options.options[0]
           },
@@ -219,7 +298,36 @@
             )
             return definition?.options?.options[index]
           },
+        },
+      }
+
+      // Utility function to get parameter value, default value, or a random value
+      function getParamValue(param, def, processor) {
+        if (typeof param !== "undefined") return param
+        if (typeof def.default !== "undefined") return def.default
+        return processor.random(def)
+      }
+
+      // params are injected into the piece using the binary representation of the
+      // numbers, to keep precision
+      function serializeParams(params, definition) {
+        // Initialization of the hex string for parameters
+        let hexString = ""
+        // If definition is not provided, return an empty hex string
+        if (!definition) return hexString
+        // Iterating over the definitions
+        for (const def of definition) {
+          const { id, type } = def
+          // Get the processor for the given type
+          const processor = processors[type]
+          // Get the param value, fall back to default or a random value
+          const paramValue = getParamValue(params[id], def, processor)
+          // Serialize the param value
+          const serializedParam = processor.serialize(paramValue, def)
+          // Concatenate serialized params
+          hexString += serializedParam
         }
+        return hexString
       }
 
       // takes the parameters as bytes and outputs an object with the
@@ -228,34 +336,44 @@
         const params = {}
         for (const def of definition) {
           const processor = processors[def.type]
-          // if we don't have any parameters defined in the URL, set the 
+          // if we don't have any parameters defined in the URL, set the
           // default value and move on
           if (!bytes) {
             let v
             if (typeof def.default === "undefined") v = processor.random(def)
             else v = def.default
-            params[def.id] = processor.constrain?.(v, def) || v;
+            params[def.id] = processor.constrain?.(v, def) || v
             continue
           }
           // extract the length from the bytes & shift the initial bytes string
-          const valueBytes = bytes.substring(0, processor.bytesLength(def?.options) * 2)
+          const valueBytes = bytes.substring(
+            0,
+            processor.bytesLength(def?.options) * 2
+          )
           bytes = bytes.substring(processor.bytesLength(def?.options) * 2)
           // deserialize the bytes into the params
-          const value =  processor.deserialize(valueBytes, def)
-          params[def.id] = processor.constrain?.(value, def) || value;
+          const value = processor.deserialize(valueBytes, def)
+          params[def.id] = processor.constrain?.(value, def) || value
         }
         return params
       }
 
-      const transformParamValues = (values, definitions) => {
+      const processParam = (paramId, value, definitions, transformer) => {
+        const definition = definitions.find((d) => d.id === paramId)
+        const processor = processors[definition.type]
+        return processor[transformer]?.(value, definition) || value
+      }
+
+      const processParams = (values, definitions, transformer) => {
         const paramValues = {}
-        for (const def of definitions) {
-          const processor = processors[def.type]
-          const value = values[def.id]
+        for (const definition of definitions) {
+          const processor = processors[definition.type]
+          const value = values[definition.id]
           // deserialize the bytes into the params
-          paramValues[def.id] = processor.transform ? processor.transform(value) : value;
+          paramValues[definition.id] =
+            processor[transformer]?.(value, definition) || value
         }
-        return paramValues; 
+        return paramValues
       }
 
       window.$fx = {
@@ -266,7 +384,44 @@
         _features: undefined,
         // where the parameter values are stored
         _paramValues: {},
-
+        _listeners: {},
+        _receiveUpdateParams: async function (newRawValues, onDefault) {
+          const handlers = await this.call("updateParams", newRawValues)
+          handlers.forEach(([handled, onDone]) => {
+            if (!handled) {
+              this._updateParams(newRawValues)
+              onDefault?.()
+            }
+            onDone?.()
+          })
+          if (handlers.length === 0) {
+            this._updateParams(newRawValues)
+            onDefault?.()
+          }
+        },
+        _updateParams: function (newRawValues) {
+          const constrained = processParams(
+            { ...this._rawValues, ...newRawValues },
+            this._params,
+            "constrain"
+          )
+          Object.keys(constrained).forEach((paramId) => {
+            this._rawValues[paramId] = constrained[paramId]
+          })
+          this._paramValues = processParams(
+            this._rawValues,
+            this._params,
+            "transform"
+          )
+          this._updateInputBytes()
+        },
+        _updateInputBytes: function () {
+          const bytes = serializeParams(this._rawValues, this._params)
+          this.inputBytes = bytes
+          const url = new URL(window.location.href)
+          url.searchParams.set("fxparams", `0x${bytes}`)
+          _updateUrl(url)
+        },
         hash: fxhash,
         rand: fxrand,
 
@@ -276,11 +431,14 @@
         preview: fxpreview,
         isPreview: isFxpreview,
         params: function(definition) {
-          // todo: maybe do some validation on the dev side ?
-          // or maybe not ?
           this._params = definition
-          this._rawValues = deserializeParams(fxparams, definition)
-          this._paramValues = transformParamValues(this._rawValues, definition)
+          this._rawValues = deserializeParams(initialInputBytes, definition)
+          this._paramValues = processParams(
+            this._rawValues,
+            definition,
+            "transform"
+          )
+          this._updateInputBytes()
         },
         features: function(features) {
           this._features = features
@@ -308,15 +466,42 @@
         },
         stringifyParams: function(params) {
           return JSON.stringify(
-            params,
+            params || this._rawValues,
             (key, value) => {
               if (typeof value === "bigint") return value.toString()
               return value
             }, 
             2,
           )
-        }
-        
+        },
+        on: function (name, callback, onDone) {
+          if (!this._listeners[name]) {
+            this._listeners[name] = []
+          }
+          this._listeners[name].push([callback, onDone])
+          return function removeListener() {
+            const index = this._listeners[eventName].findIndex(
+              ([c]) => c === callback
+            )
+            if (index > -1) {
+              this._listeners[eventName].splice(index, 1)
+            }
+          }
+        },
+        call: async function (name, data) {
+          const results = []
+          if (this._listeners && this._listeners[name]) {
+            for (const [callback, onDone] of this._listeners[name]) {
+              const result = callback(data)
+              if (result instanceof Promise) {
+                results.push([await result, onDone])
+              } else {
+                results.push([result, onDone])
+              }
+            }
+          }
+          return results
+        },
       }
       window.addEventListener("message", (event) => {
         if (event.data === "fxhash_getInfo") {
@@ -333,6 +518,10 @@
               minter: window.$fx.minter,
             },
           }, "*")
+        }
+        if (event.data?.id === "fxhash_updateParams") {
+          const { params } = event.data.data
+          if (params) window.$fx._receiveUpdateParams(params)
         }
       })
       // END NEW

--- a/project/public/index.html
+++ b/project/public/index.html
@@ -7,8 +7,9 @@
       //---- do not edit the following code (you can indent as you wish)
       let search = new URLSearchParams(window.location.search)
       let alphabet = "123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ"
-      var fxhash = search.get('fxhash') || "oo" + Array(49).fill(0).map(_=>alphabet[(Math.random()*alphabet.length)|0]).join('')
       let b58dec = str=>[...str].reduce((p,c)=>p*alphabet.length+alphabet.indexOf(c)|0, 0)
+      // make fxrand from hash
+      var fxhash = search.get('fxhash') || "oo" + Array(49).fill(0).map(_=>alphabet[(Math.random()*alphabet.length)|0]).join('')
       let fxhashTrunc = fxhash.slice(2)
       let regex = new RegExp(".{" + ((fxhash.length/4)|0) + "}", 'g')
       let hashes = fxhashTrunc.match(regex).map(h => b58dec(h))
@@ -25,6 +26,16 @@
         }
       }
       var fxrand = sfc32(...hashes)
+      // make fxrandminter from minter address
+      var fxminter = search.get('fxminter') || "tz1" + Array(33).fill(0).map(_=>alphabet[(Math.random()*alphabet.length)|0]).join('')
+      let fxminterTrunc = fxminter.slice(3)
+      regex = new RegExp(".{" + ((fxminterTrunc.length/4)|0) + "}", 'g')
+      hashes = fxminterTrunc.match(regex).map(h => b58dec(h))
+      var fxrandminter = sfc32(...hashes)
+
+      // get the iteration #
+      var fxiter = parseInt(search.get("fxiter"))
+
       // true if preview mode active, false otherwise
       // you can append preview=1 to the URL to simulate preview active
       var isFxpreview = search.get('preview') === "1"
@@ -260,6 +271,12 @@
 
         hash: fxhash,
         rand: fxrand,
+
+        minter: fxminter,
+        randminter: fxrandminter,
+
+        iter: () => fxiter,
+
         preview: fxpreview,
         isPreview: isFxpreview,
         params: function(definition) {
@@ -310,6 +327,20 @@
           parent.postMessage({
             id: "fxhash_getHash",
             data: window.$fx.hash
+          }, "*")
+        }
+
+        if (event.data === "fxhash_getMinter") {
+          parent.postMessage({
+            id: "fxhash_getMinter",
+            data: window.$fx.minter
+          }, "*")
+        }
+
+        if (event.data === "fxhash_getIteration") {
+          parent.postMessage({
+            id: "fxhash_getIteration",
+            data: window.$fx.iter(),
           }, "*")
         }
         

--- a/project/public/index.html
+++ b/project/public/index.html
@@ -486,6 +486,11 @@
         getRawParams: function() {
           return this._rawValues
         },
+        getRandomParam: function(id) {
+          const definition = this._params.find(d => d.id === id)
+          const processor = processors[definition.type]
+          return processor.random(definition)
+        },
         getDefinitions: function() {
           return this._params
         },

--- a/project/public/index.html
+++ b/project/public/index.html
@@ -8,11 +8,6 @@
       let search = new URLSearchParams(window.location.search)
       let alphabet = "123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ"
       let b58dec = str=>[...str].reduce((p,c)=>p*alphabet.length+alphabet.indexOf(c)|0, 0)
-      // make fxrand from hash
-      var fxhash = search.get('fxhash') || "oo" + Array(49).fill(0).map(_=>alphabet[(Math.random()*alphabet.length)|0]).join('')
-      let fxhashTrunc = fxhash.slice(2)
-      let regex = new RegExp(".{" + ((fxhash.length/4)|0) + "}", 'g')
-      let hashes = fxhashTrunc.match(regex).map(h => b58dec(h))
       let sfc32 = (a, b, c, d) => {
         return () => {
           a |= 0; b |= 0; c |= 0; d |= 0
@@ -25,13 +20,14 @@
           return (t >>> 0) / 4294967296
         }
       }
-      var fxrand = sfc32(...hashes)
+      let rndHash = (n) => Array(n).fill(0).map(_=>alphabet[(Math.random()*alphabet.length)|0]).join("")
+      let matcher = (str, start) => str.slice(start).match(new RegExp(".{"+((str.length-start)>>2)+"}","g")).map(b58dec)
+      // make fxrand from hash
+      var fxhash = search.get("fxhash") || "oo" + rndHash(49)
+      var fxrand = sfc32(...matcher(fxhash, 2))
       // make fxrandminter from minter address
-      var fxminter = search.get('fxminter') || "tz1" + Array(33).fill(0).map(_=>alphabet[(Math.random()*alphabet.length)|0]).join('')
-      let fxminterTrunc = fxminter.slice(3)
-      regex = new RegExp(".{" + ((fxminterTrunc.length/4)|0) + "}", 'g')
-      hashes = fxminterTrunc.match(regex).map(h => b58dec(h))
-      var fxrandminter = sfc32(...hashes)
+      var fxminter = search.get("fxminter") || "tz1" + rndHash(33)
+      var fxrandminter = sfc32(...matcher(fxminter, 3))
       // true if preview mode active, false otherwise
       // you can append preview=1 to the URL to simulate preview active
       var isFxpreview = search.get('preview') === "1"
@@ -438,12 +434,20 @@
         },
         hash: fxhash,
         rand: fxrand,
-
         minter: fxminter,
         randminter: fxrandminter,
+        resetRandSeed: function() {
+          this.rand = fxrand = sfc32(...matcher(this.hash, 2))
+        },
+        resetRandminterSeed: function() {
+          this.randminter = fxminter = sfc32(...matcher(this.minter, 3))
+        },
+        resetSeed: function() {
+          this.resetRandSeed()
+          this.resetRandminterSeed()
+        },
 
         iteration: search.get('fxiteration') || 1,
-
         context: search.get("fxcontext") || "standalone",
 
         preview: fxpreview,

--- a/project/public/index.html
+++ b/project/public/index.html
@@ -439,7 +439,7 @@
         rand: fxrand,
         minter: fxminter,
         randminter: fxrandminter,
-        iteration: search.get('fxiteration') || 1,
+        iteration: Number(search.get('fxiteration')) || 1,
         context: search.get("fxcontext") || "standalone",
 
         preview: fxpreview,

--- a/project/public/index.html
+++ b/project/public/index.html
@@ -33,9 +33,6 @@
       hashes = fxminterTrunc.match(regex).map(h => b58dec(h))
       var fxrandminter = sfc32(...hashes)
 
-      // get the iteration #
-      var fxiter = parseInt(search.get("fxiter"))
-
       // true if preview mode active, false otherwise
       // you can append preview=1 to the URL to simulate preview active
       var isFxpreview = search.get('preview') === "1"
@@ -45,9 +42,6 @@
         // window.dispatchEvent(new Event("fxhash-preview"))
         // setTimeout(() => fxpreview(), 500)
       }
-      //
-      // NEW: v2 of the fxhash SDK lol
-      //
       // get the byte params from the URL
       let fxparams = search.get('fxparams')
       fxparams = fxparams ? fxparams.replace("0x", "") : fxparams
@@ -279,8 +273,6 @@
         minter: fxminter,
         randminter: fxrandminter,
 
-        iter: () => fxiter,
-
         preview: fxpreview,
         isPreview: isFxpreview,
         params: function(definition) {
@@ -338,6 +330,7 @@
                 definitions: window.$fx.getDefinitions(),
                 values: window.$fx.getRawParams(),
               },
+              minter: window.$fx.minter,
             },
           }, "*")
         }

--- a/project/public/index.html
+++ b/project/public/index.html
@@ -439,17 +439,6 @@
         rand: fxrand,
         minter: fxminter,
         randminter: fxrandminter,
-        resetRandSeed: function() {
-          this.rand = fxrand = sfc32(...matcher(this.hash, 2))
-        },
-        resetRandminterSeed: function() {
-          this.randminter = fxminter = sfc32(...matcher(this.minter, 3))
-        },
-        resetSeed: function() {
-          this.resetRandSeed()
-          this.resetRandminterSeed()
-        },
-
         iteration: search.get('fxiteration') || 1,
         context: search.get("fxcontext") || "standalone",
 
@@ -542,6 +531,18 @@
           }
         },
       }
+      const resetFxRand = () => {
+        fxrand = sfc32(...matcher(fxhash, 2))
+        $fx.rand = fxrand
+        fxrand.reset = resetFxRand
+      }
+      fxrand.reset = resetFxRand
+      const resetFxRandMinter = () => {
+        fxrandminter = sfc32(...matcher(fxminter, 3))
+        $fx.randminter = fxrandminter
+        fxrandminter.reset = resetFxRandMinter
+      }
+      fxrandminter.reset = resetFxRandMinter
       window.addEventListener("message", (event) => {
         if (event.data === "fxhash_getInfo") {
           parent.postMessage({

--- a/project/src/index.js
+++ b/project/src/index.js
@@ -1,12 +1,8 @@
 // demonstrate seed reset
 // for (let i = 0; i < 10; i++) {
 //   console.log(i, $fx.rand(), $fx.randminter())
-// }
-
-// $fx.resetSeed();
-
-// for (let i = 0; i < 10; i++) {
-//   console.log(i, $fx.rand(), $fx.randminter())
+//   $fx.rand.reset();
+//   $fx.randminter.reset();
 // }
 
 const sp = new URLSearchParams(window.location.search);

--- a/project/src/index.js
+++ b/project/src/index.js
@@ -1,8 +1,8 @@
-console.log(fxhash)
-console.log(fxrand())
+// console.log(fxhash);
+// console.log(fxrand());
 
-const sp = new URLSearchParams(window.location.search);
-console.log(sp);
+const sp = new URLSearchParams(window.location.search)
+//  console.log(sp);
 
 // this is how to define parameters
 $fx.params([
@@ -11,13 +11,14 @@ $fx.params([
     name: "A number/float64",
     type: "number",
     //default: Math.PI,
+    update: "sync",
     options: {
       min: 1,
       max: 10,
-      step: 0.00000000000001,
+      step: 0.0001,
     },
   },
-  
+
   {
     id: "bigint_id",
     name: "A bigint",
@@ -36,8 +37,8 @@ $fx.params([
     //default: "hello",
     options: {
       minLength: 1,
-      maxLength: 512
-    }
+      maxLength: 512,
+    },
   },
   {
     id: "select_id",
@@ -46,12 +47,13 @@ $fx.params([
     //default: "pear",
     options: {
       options: ["apple", "orange", "pear"],
-    }
+    },
   },
   {
     id: "color_id",
     name: "A color",
     type: "color",
+    update: "sync",
     //default: "ff0000",
   },
   {
@@ -67,50 +69,73 @@ $fx.params([
     //default: "hello",
     options: {
       minLength: 1,
-      maxLength: 512
-    }
+      maxLength: 512,
+    },
   },
-]);
+])
 
 // this is how features can be defined
 $fx.features({
   "A random feature": Math.floor($fx.rand() * 10),
   "A random boolean": $fx.rand() > 0.5,
-  "A random string": ["A", "B", "C", "D"].at(Math.floor($fx.rand()*4)),
+  "A random string": ["A", "B", "C", "D"].at(Math.floor($fx.rand() * 4)),
   "Feature from params, its a number": $fx.getParam("number_id"),
 })
 
-// log the parameters, for debugging purposes, artists won't have to do that
-console.log("Current param values:")
-// Raw deserialize param values 
-console.log($fx.getRawParams())
-// Added addtional transformation to the parameter for easier usage
-// e.g. color.hex.rgba, color.obj.rgba.r, color.arr.rgb[0] 
-console.log($fx.getParams())
+function main() {
+  // log the parameters, for debugging purposes, artists won't have to do that
+  // console.log("Current param values:");
+  // // Raw deserialize param values
+  // console.log($fx.getRawParams());
+  // // Added addtional transformation to the parameter for easier usage
+  // // e.g. color.hex.rgba, color.obj.rgba.r, color.arr.rgb[0]
+  // console.log($fx.getParams());
 
-// how to read a single raw parameter
-console.log("Single raw value:")
-console.log($fx.getRawParam("color_id"));
-// how to read a single transformed parameter
-console.log("Single transformed value:")
-console.log($fx.getParam("color_id"));
+  // // how to read a single raw parameter
+  // console.log("Single raw value:");
+  // console.log($fx.getRawParam("color_id"));
+  // // how to read a single transformed parameter
+  // console.log("Single transformed value:");
+  // console.log($fx.getParam("color_id"));
 
-// update the document based on the parameters
-document.body.style.background = $fx.getParam("color_id").hex.rgba
-document.body.innerHTML = `
-<p>
-url: ${window.location.href}
-</p>
-<p>
-hash: ${$fx.hash}
-</p>
-<p>
-params:
-</p>
-<pre>
-${$fx.stringifyParams($fx.getRawParams())}
-</pre>
-<pre style="color: white;">
-${$fx.stringifyParams($fx.getRawParams())}
-</pre>
-`
+  const getContrastTextColor = (backgroundColor) =>
+    ((parseInt(backgroundColor, 16) >> 16) & 0xff) > 0xaa
+      ? "#000000"
+      : "#ffffff"
+
+  const bgcolor = $fx.getParam("color_id").hex.rgba
+  const textcolor = getContrastTextColor(bgcolor.replace("#", ""))
+
+  // update the document based on the parameters
+  document.body.style.background = bgcolor
+  document.body.innerHTML = `
+  <div style="color: ${textcolor};">
+    <p>
+    hash: ${$fx.hash}
+    </p>
+    <p>
+    minter: ${$fx.minter}
+    </p>
+    <p>
+    inputBytes: ${$fx.inputBytes}
+    </p>
+    <p>
+    params:
+    </p>
+    <pre>
+    ${$fx.stringifyParams($fx.getRawParams())}
+    </pre>
+  <div>
+  `
+}
+
+main()
+
+$fx.on(
+  "updateParams",
+  (newRawValues) => {
+    if (newRawValues.number_id.value === 5) return true
+    return false
+  },
+  () => main()
+)

--- a/project/src/index.js
+++ b/project/src/index.js
@@ -9,7 +9,7 @@
 //   console.log(i, $fx.rand(), $fx.randminter())
 // }
 
-const sp = new URLSearchParams(window.location.search)
+const sp = new URLSearchParams(window.location.search);
 //  console.log(sp);
 
 // this is how to define parameters
@@ -19,7 +19,7 @@ $fx.params([
     name: "A number/float64",
     type: "number",
     //default: Math.PI,
-    update: "sync",
+    update: "code-driven",
     options: {
       min: 1,
       max: 10,
@@ -31,6 +31,7 @@ $fx.params([
     id: "bigint_id",
     name: "A bigint",
     type: "bigint",
+    update: "code-driven",
     //default: BigInt(Number.MAX_SAFE_INTEGER * 2),
     options: {
       min: Number.MIN_SAFE_INTEGER * 4,
@@ -42,6 +43,7 @@ $fx.params([
     id: "string_id_long",
     name: "A string long",
     type: "string",
+    update: "code-driven",
     //default: "hello",
     options: {
       minLength: 1,
@@ -52,6 +54,7 @@ $fx.params([
     id: "select_id",
     name: "A selection",
     type: "select",
+    update: "code-driven",
     //default: "pear",
     options: {
       options: ["apple", "orange", "pear"],
@@ -61,26 +64,28 @@ $fx.params([
     id: "color_id",
     name: "A color",
     type: "color",
-    update: "sync",
+    update: "code-driven",
     //default: "ff0000",
   },
   {
     id: "boolean_id",
     name: "A boolean",
     type: "boolean",
+    update: "code-driven",
     //default: true,
   },
   {
     id: "string_id",
     name: "A string",
     type: "string",
+    update: "code-driven",
     //default: "hello",
     options: {
       minLength: 1,
       maxLength: 512,
     },
   },
-])
+]);
 
 // this is how features can be defined
 $fx.features({
@@ -88,7 +93,7 @@ $fx.features({
   "A random boolean": $fx.rand() > 0.5,
   "A random string": ["A", "B", "C", "D"].at(Math.floor($fx.rand() * 4)),
   "Feature from params, its a number": $fx.getParam("number_id"),
-})
+});
 
 function main() {
   // log the parameters, for debugging purposes, artists won't have to do that
@@ -109,13 +114,13 @@ function main() {
   const getContrastTextColor = (backgroundColor) =>
     ((parseInt(backgroundColor, 16) >> 16) & 0xff) > 0xaa
       ? "#000000"
-      : "#ffffff"
+      : "#ffffff";
 
-  const bgcolor = $fx.getParam("color_id").hex.rgba
-  const textcolor = getContrastTextColor(bgcolor.replace("#", ""))
+  const bgcolor = $fx.getParam("color_id").hex.rgba;
+  const textcolor = getContrastTextColor(bgcolor.replace("#", ""));
 
   // update the document based on the parameters
-  document.body.style.background = bgcolor
+  document.body.style.background = bgcolor;
   document.body.innerHTML = `
   <div style="color: ${textcolor};">
     <p>
@@ -123,6 +128,9 @@ function main() {
     </p>
     <p>
     minter: ${$fx.minter}
+    </p>
+    <p>
+    iteration: ${$fx.iteration}
     </p>
     <p>
     inputBytes: ${$fx.inputBytes}
@@ -137,25 +145,33 @@ function main() {
     ${$fx.stringifyParams($fx.getRawParams())}
     </pre>
   <div>
-  `
-  const btn = document.createElement("button")
-  btn.textContent = "Sync number_id"
+  `;
+  const btn = document.createElement("button");
+  btn.textContent = "emit random params";
   btn.addEventListener("click", () => {
-    $fx.emit("params:update", { number_id: Math.random() * 9 + 1 })
-    main()
-  })
-  document.body.appendChild(btn)
+    $fx.emit("params:update", {
+      number_id: $fx.getRandomParam("number_id"),
+      bigint_id: $fx.getRandomParam("bigint_id"),
+      string_id_long: $fx.getRandomParam("string_id_long"),
+      select_id: $fx.getRandomParam("select_id"),
+      color_id: $fx.getRandomParam("color_id"),
+      boolean_id: $fx.getRandomParam("boolean_id"),
+      string_id: $fx.getRandomParam("string_id"),
+    });
+    main();
+  });
+  document.body.appendChild(btn);
 }
 
-main()
+main();
 
 $fx.on(
   "params:update",
   (newRawValues) => {
     // opt-out default behaviour
-    if (newRawValues.number_id === 5) return false
+    if (newRawValues.number_id === 5) return false;
     // opt-in default behaviour
-    return true
+    return true;
   },
   (optInDefault, newValues) => main()
-)
+);

--- a/project/src/index.js
+++ b/project/src/index.js
@@ -1,5 +1,13 @@
-// console.log(fxhash);
-// console.log(fxrand());
+// demonstrate seed reset
+// for (let i = 0; i < 10; i++) {
+//   console.log(i, $fx.rand(), $fx.randminter())
+// }
+
+// $fx.resetSeed();
+
+// for (let i = 0; i < 10; i++) {
+//   console.log(i, $fx.rand(), $fx.randminter())
+// }
 
 const sp = new URLSearchParams(window.location.search)
 //  console.log(sp);

--- a/project/src/index.js
+++ b/project/src/index.js
@@ -133,7 +133,7 @@ function main() {
   const btn = document.createElement("button")
   btn.textContent = "Sync number_id"
   btn.addEventListener("click", () => {
-    $fx.emit("updateParams", { number_id: Math.random() * 9 + 1 })
+    $fx.emit("params:update", { number_id: Math.random() * 9 + 1 })
     main()
   })
   document.body.appendChild(btn)

--- a/project/src/index.js
+++ b/project/src/index.js
@@ -127,6 +127,13 @@ function main() {
     </pre>
   <div>
   `
+  const btn = document.createElement("button")
+  btn.textContent = "Sync number_id"
+  btn.addEventListener("click", () => {
+    $fx.emit("updateParams", { number_id: Math.random() * 9 + 1 })
+    main()
+  })
+  document.body.appendChild(btn)
 }
 
 main()


### PR DESCRIPTION
__________________
> Use this branch with the fxlens companion branch: https://github.com/fxhash/fxlens/pull/21
__________________

This PR adds: 
- __`$fx.emit` for emitting data from artwork to the parent__
- __`$fx.iteration` exposing the iteration number__
- __helpers to reset the seeds__

# Emitting data from artwork to the parent via `$fx.emit()`

A new function called `$fx.emit` allows to emit data to the parent of the artwork. This means you can e.g. update the controllers of the minting interface from the artwork's code directly. This feature solves the "Pensado a mano"-usecase 🐰. It allows an artist to create custom interfaces on their artworks or receive any kind of input from collectors and emit those inputs back to the ui of the parent. 

#### `$fx.emit()`
```ts
$fx.emit(
  // the id of the emission event
  id: string,
  // the data send through the emission
  data: Record<string,any>,
)
```

## Emitting param updates

For now there is only one valid event id to be used with the `$fx.emit()` function: `"params:update"`.
Same as with the "sync" update mode for parameters, it is depending on the artwork, if you need to call your render function after `$fx.emit()` was called. To sync the `number_id` parameter with a random value upon button click you could use the following code snippet. 

```js
const btn = document.createElement("button")
btn.textContent = "Sync number_id"
btn.addEventListener("click", () => {
  $fx.emit("params:update", { number_id: Math.random() * 9 + 1 })
  // call your render function if you don't render in a loop
  main()
})
```

Of course the `params:update` emission is part of the `params:update` data-flow. This means by subscribing to the `$fx.on("params:update")` event you are able to cancel the emission via the event handler. 

# `$fx.iteration`

You can now access the current iteration number via `$fx.iteration`. Nothing much more to know than our __guidlines__ for using the iteration number in your artwork: <link to guidelines>

# Resetting the seed

The API now exposes helper functions for resetting the seed of the PRNG `$fx.rand()` and `$fx.randminter()`. 
The following functions are available:
- `$fx.rand.reset()`: Resets the seed for the `$fx.rand()` function
- `$fx.randminter.reset()`: Resets the seed for the `$rx.randminter()` function


# Random param value

For convenience reason (and because the funcioanlity is included in the snippet already, exposing a function to generate a random param value for a specific param id.

- `$fx.getRandomParam(id: string)`: Returns a random value within the constrains of the parameter definition
